### PR TITLE
:bug: Allow user to specify BioFormats channels

### DIFF
--- a/+utils/CHIPS_version.m
+++ b/+utils/CHIPS_version.m
@@ -29,8 +29,8 @@ narginchk(0, 0);
 
 verMajor = 1; %MAJOR_VER
 verMinor = 1; %MINOR_VER
-verBug = 1; %BUG_VER
-verBuild = 65; %BUILD_VER
+verBug = 2; %BUG_VER
+verBuild = 66; %BUILD_VER
 
 verStr = sprintf('%d.%d.%d.%d', verMajor, verMinor, verBug, verBuild);
 

--- a/@BioFormats/import_image.m
+++ b/@BioFormats/import_image.m
@@ -27,6 +27,11 @@ if isempty(self.filename)
     return
 end
 
+% Check if the user specified channels
+if ~isempty(channels)
+    forceUserChannels = true;
+end
+
 % Get the full file path. Required for some of the Java classes
 [path, ~, ~] = fileparts(self.filename);
 if isempty(path)
@@ -157,7 +162,7 @@ if ~hasCalibIn
             @CalibrationPixelSize.funRawDummy);
     end
 
-    if hasChannels
+    if hasChannels && ~forceUserChannels
         channels = channelsOME;
     end
 

--- a/@Metadata/Metadata.m
+++ b/@Metadata/Metadata.m
@@ -526,7 +526,7 @@ classdef Metadata
                 isKnown = ismember(iName, self.knownChannels);
                 
                 if ~isKnown
-                    error('Metadata:SetChannels:UnknownChannel', ...
+                    warning('Metadata:SetChannels:UnknownChannel', ...
                         '"%s" is not a recognised channel name', iName)
                 end
 


### PR DESCRIPTION
+ Channel specifications were ignored when loading BioFormats images with channels already defined in metadata. These can now be overwritten by the user by supplying a channels struct on load.
+ Change Metadata unknown channel error to warning to allow loading images with unknown channel identifiers