### PR TITLE
Support Newer ScanImage TIFs

### DIFF
--- a/+utils/+scim/parseHeader.m
+++ b/+utils/+scim/parseHeader.m
@@ -1,20 +1,22 @@
-function header=parseHeader(input)
+function header = parseHeader(input, prefix)
 % PARSEHEADER   - Read ScanImage Header String and return structure.
 %   PARSEHEADER will output the value of the header fields as a structure.
 %   Input is the header from ScanImage TIF File (char array).
+%   prefix is the 'name' given to each data point
 %
 % See also
 
 out={};
+prefixLen = numel(prefix);
 tempcell=strread(input,'%q'); 
 for lineCounter=1:length(tempcell)
     data=tempcell{lineCounter};
-    if ~strncmp(data,'state.',6)
+    if ~strncmp(data, prefix, prefixLen)
         out{end}=[out{end} ' ' data(1:end-1)];
         continue
     end
     equal=findstr('=',data);
-    param=data(7:equal-1);
+    param=data(prefixLen + 1:equal-1);
     val=data(equal+1:end);
     if isempty(val)
         val=[];

--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,5 @@ $RECYCLE.BIN/
 *.vpp*~*
 *.vux
 *.vbak*
+.tif
+*.tif

--- a/tests/Test_SCIM_Tif.m
+++ b/tests/Test_SCIM_Tif.m
@@ -9,6 +9,7 @@ classdef Test_SCIM_Tif < matlab.unittest.TestCase
         fnSCIMXSectScan = 'xsectscan_scim.tif';
         fnSCIMCellScan = 'cellscan_scim.tif';
         fnSCIMFRET = 'xsectscan_scim.tif';
+        fnSCIMV5 = 'ScanImageBigTIFFv57.tif';
         skipImport = true;
     end
     


### PR DESCRIPTION
Resolves #2.

This PR introduces support for TIFs generated with newer files - either V5 or V2016+. This means that users may now use the built in `SCIM_Tif` class when reading SI TIFs instead of manually constructing them with `RawImageDummy`.

I have an SI5 TIF ready for testing, and as you see I added it to the tests file, but I'm not sure how you would like to include it "officially". I will also add a SI2020 file to the mix.